### PR TITLE
Consumer bug fix

### DIFF
--- a/lib/Util.pm
+++ b/lib/Util.pm
@@ -73,7 +73,7 @@ sub get_identity {
             consumer   => bless($consumer,"Net::OpenID::Consumer"),
             error      => $consumer->err(),
             error_code => $consumer->errcode(),
-            error_json => $consumer->jsonerr(),
+            error_json => $consumer->json_err(),
             claimed    => 1
         }
     }


### PR DESCRIPTION
get_identity in Util.pm is using an incorrect function call.

Change it to use
consumer->json_err()
instead of
consumer->jsonerr().

Thanks.
